### PR TITLE
Add patch to differentiate between FN980 hw revisions

### DIFF
--- a/patches/0061-drivers-bus-mhi-differentiate-between-FN980-v1-and-v.patch
+++ b/patches/0061-drivers-bus-mhi-differentiate-between-FN980-v1-and-v.patch
@@ -1,0 +1,71 @@
+From 76383cba875eaf67227d58013384f62dbbbf3310 Mon Sep 17 00:00:00 2001
+From: Daniele Palmas <dnlplm@gmail.com>
+Date: Wed, 9 Feb 2022 13:54:32 +0100
+Subject: [PATCH 61/61] drivers: bus: mhi: differentiate between FN980 v1 and
+ v2
+
+FN980 v1 hardware supports just QMI legacy, QRTR and rmnet netdevice,
+so remove unused devices.
+
+Remove also MBIM control channel for both hardware revisions.
+
+Signed-off-by: Daniele Palmas <dnlplm@gmail.com>
+---
+ drivers/bus/mhi/pci_generic.c | 31 ++++++++++++++++++++++++++++---
+ 1 file changed, 28 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/bus/mhi/pci_generic.c b/drivers/bus/mhi/pci_generic.c
+index 847eb62888b5..4a6f58e3beb5 100644
+--- a/drivers/bus/mhi/pci_generic.c
++++ b/drivers/bus/mhi/pci_generic.c
+@@ -377,8 +377,6 @@ static const struct mhi_channel_config mhi_telit_fn980_channels[] = {
+ 	MHI_CHANNEL_CONFIG_DL_SBL(3, "SAHARA", 32, 0),
+ 	MHI_CHANNEL_CONFIG_AMSS_SBL_UL(4, "DIAG", 64, 1),
+ 	MHI_CHANNEL_CONFIG_AMSS_SBL_DL(5, "DIAG", 64, 1),
+-	MHI_CHANNEL_CONFIG_UL(12, "MBIM", 4, 0),
+-	MHI_CHANNEL_CONFIG_DL(13, "MBIM", 4, 0),
+ 	MHI_CHANNEL_CONFIG_UL(14, "QMI", 16, 0),
+ 	MHI_CHANNEL_CONFIG_DL(15, "QMI", 16, 0),
+ 	MHI_CHANNEL_CONFIG_UL(20, "IPCR", 16, 0),
+@@ -418,10 +416,37 @@ static const struct mhi_pci_dev_info mhi_telit_fn980_info = {
+ 	.dma_data_width = 32
+ };
+ 
++static const struct mhi_channel_config mhi_telit_fn980_hw_v1_channels[] = {
++	MHI_CHANNEL_CONFIG_UL(14, "QMI", 32, 0),
++	MHI_CHANNEL_CONFIG_DL(15, "QMI", 32, 0),
++	MHI_CHANNEL_CONFIG_UL(20, "IPCR", 16, 0),
++	MHI_CHANNEL_CONFIG_DL(21, "IPCR", 16, 0),
++	MHI_CHANNEL_CONFIG_HW_UL(100, "IP_HW0", 128, 2),
++	MHI_CHANNEL_CONFIG_HW_DL(101, "IP_HW0", 128, 3),
++};
++
++static struct mhi_controller_config modem_telit_fn980_hw_v1_config = {
++	.max_channels = 128,
++	.timeout_ms = 20000,
++	.num_channels = ARRAY_SIZE(mhi_telit_fn980_hw_v1_channels),
++	.ch_cfg = mhi_telit_fn980_hw_v1_channels,
++	.num_events = ARRAY_SIZE(mhi_telit_fn980_events),
++	.event_cfg = mhi_telit_fn980_events,
++};
++
++static const struct mhi_pci_dev_info mhi_telit_fn980_hw_v1_info = {
++	.name = "telit-fn980",
++	.fw = "qcom/sdx55m/sbl1.mbn",
++	.edl = "qcom/sdx55m/edl.mbn",
++	.config = &modem_telit_fn980_hw_v1_config,
++	.bar_num = MHI_PCI_DEFAULT_BAR_NUM,
++	.dma_data_width = 32,
++};
++
+ static const struct pci_device_id mhi_pci_id_table[] = {
+ 	/* FN980 firmware release having Telit subvendor-id */
+ 	{ PCI_DEVICE_SUB(PCI_VENDOR_ID_QCOM, 0x0306, 0x1C5D, 0x2000),
+-		.driver_data = (kernel_ulong_t) &mhi_telit_fn980_info },
++		.driver_data = (kernel_ulong_t) &mhi_telit_fn980_hw_v1_info },
+ 	/* Modifying also Qualcomm default entry for FN980 firmware release without Telit subvendor-id */
+ 	{ PCI_DEVICE(PCI_VENDOR_ID_QCOM, 0x0306),
+ 		.driver_data = (kernel_ulong_t) &mhi_telit_fn980_info },
+-- 
+2.32.0
+


### PR DESCRIPTION
Remove also MBIM control channel, since unsupported.

@CarloLoTelit @enricosau 